### PR TITLE
Remove dsdoc.net link

### DIFF
--- a/paxos-made-simple/README.rst
+++ b/paxos-made-simple/README.rst
@@ -1,5 +1,5 @@
 | 原文链接： `Paxos Made Simple <http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf>`_，2001-11-01
-| 译文发在 `dsdoc.net <http://dsdoc.net/>`_： `【译】Paxos Made Simple <http://dsdoc.net/paxosmadesimple/index.html>`_，2012-12-31
+| 译文发在： `【译】Paxos Made Simple <https://web.archive.org/web/20180530124902/http://dsdoc.net/paxosmadesimple/index.html>`_，2012-12-31
 
 .. highlight:: c
 

--- a/paxoslease/README.rst
+++ b/paxoslease/README.rst
@@ -1,5 +1,5 @@
 | 原文链接： `PaxosLease: Diskless Paxos for Leases <http://arxiv.org/pdf/1209.4187.pdf>`_，2012-09-19
-| 译文发在 `dsdoc.net <http://dsdoc.net/>`_： `【译】PaxosLease：实现租约的无盘Paxos算法 <http://dsdoc.net/paxoslease/index.html>`_，2013-01-04
+| 译文发在： `【译】PaxosLease：实现租约的无盘Paxos算法 <https://web.archive.org/web/20170705103429/http://dsdoc.net/paxoslease/index.html>`_，2013-01-04
 
 .. highlight:: c
 


### PR DESCRIPTION
dsdoc.net 域名已不再是论文翻译网站.

将相应的链接转换成 archive 历史页面.